### PR TITLE
Fix regression caused by assigning arrays and objects inside init()

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,6 +16,7 @@ module.exports = {
     browser: true
   },
   rules: {
+    'ember/avoid-leaking-state-in-ember-objects': 'off',
   },
   overrides: [
     // node files

--- a/addon/adapters/cloud-firestore.js
+++ b/addon/adapters/cloud-firestore.js
@@ -34,18 +34,14 @@ export default RESTAdapter.extend({
   defaultSerializer: 'cloud-firestore',
 
   /**
+   * @override
+   */
+  headers: { 'Content-Type': 'application/json' },
+
+  /**
    * @type {boolean}
    */
   willUnloadRecordOnListenError: true,
-
-  /**
-   * @override
-   */
-  init(...args) {
-    this._super(...args);
-
-    this.set('headers', { 'Content-Type': 'application/json' });
-  },
 
   /**
    * @override

--- a/addon/instance-initializers/cloud-firestore.js
+++ b/addon/instance-initializers/cloud-firestore.js
@@ -37,13 +37,9 @@ function reopenStore(appInstance) {
     firebase: inject(),
 
     /**
-     * @override
+     * @type {Object}
      */
-    init(...args) {
-      this._super(...args);
-
-      this.set('tracker', {});
-    },
+    tracker: {},
 
     /**
      * @type {Ember.Service}

--- a/tests/dummy/app/controllers/mirage.js
+++ b/tests/dummy/app/controllers/mirage.js
@@ -1,14 +1,7 @@
 import Controller from '@ember/controller';
 
 export default Controller.extend({
-  /**
-   * @override
-   */
-  init(...args) {
-    this._super(...args);
-
-    this.set('users', []);
-  },
+  users: [],
 
   async handleCreateRecordClick() {
     const user = await this.get('store').createRecord('user', {

--- a/tests/unit/instance-initializers/cloud-firestore-test.js
+++ b/tests/unit/instance-initializers/cloud-firestore-test.js
@@ -46,8 +46,6 @@ module('Unit | Instance Initializer | store', function(hooks) {
       const pushStub = sinon.stub();
       const store = this.owner.lookup('service:store');
 
-      store.init();
-
       store.set('normalize', normalizeStub);
       store.set('push', pushStub);
 
@@ -98,8 +96,6 @@ module('Unit | Instance Initializer | store', function(hooks) {
       const unloadRecordStub = sinon.stub();
       const store = this.owner.lookup('service:store');
 
-      store.init();
-
       store.set('peekRecord', peekRecordStub);
       store.set('unloadRecord', unloadRecordStub);
 
@@ -137,8 +133,6 @@ module('Unit | Instance Initializer | store', function(hooks) {
       const unloadRecordStub = sinon.stub();
       const store = this.owner.lookup('service:store');
 
-      store.init();
-
       store.set('adapterFor', adapterForStub);
       store.set('peekRecord', peekRecordStub);
       store.set('unloadRecord', unloadRecordStub);
@@ -173,8 +167,6 @@ module('Unit | Instance Initializer | store', function(hooks) {
       const peekRecordStub = sinon.stub().returns(record);
       const unloadRecordStub = sinon.stub();
       const store = this.owner.lookup('service:store');
-
-      store.init();
 
       store.set('adapterFor', adapterForStub);
       store.set('peekRecord', peekRecordStub);
@@ -213,8 +205,6 @@ module('Unit | Instance Initializer | store', function(hooks) {
       const findRecordStub = sinon.stub();
       const store = this.owner.lookup('service:store');
 
-      store.init();
-
       store.set('findRecord', findRecordStub);
 
       // Act
@@ -236,8 +226,6 @@ module('Unit | Instance Initializer | store', function(hooks) {
         _internalModel: { id: 'ID', name: 'Name' },
       });
       const store = this.owner.lookup('service:store');
-
-      store.init();
       const queryRef = {
         onSnapshot(onSuccess) {
           store.get('tracker')._query.queryId.recordArray = ArrayProxy.create({
@@ -295,8 +283,6 @@ module('Unit | Instance Initializer | store', function(hooks) {
       const hasManyStub = sinon.stub().returns({ reload: reloadStub });
       const peekRecordStub = sinon.stub().returns({ hasMany: hasManyStub });
       const store = this.owner.lookup('service:store');
-
-      store.init();
 
       store.set('tracker', {
         user: { document: { user_a: { relationship: {} } } },


### PR DESCRIPTION
Moving `tracker` declaration inside `init()` caused some bugs. This PR reverts that changes. We use immutability to avoid leaking object states.