### PR TITLE
Add mock-cloud-firestore test helper

### DIFF
--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,0 +1,1 @@
+export { default as mockFirebase } from './mocks/cloud-firestore';

--- a/addon-test-support/mocks/cloud-firestore.js
+++ b/addon-test-support/mocks/cloud-firestore.js
@@ -1,0 +1,23 @@
+import MockFirebase from 'mock-cloud-firestore';
+import Service from '@ember/service';
+
+/**
+ * Mocks Cloud Firestore
+ *
+ * @param {Object} context
+ * @param {Object} fixtureData
+ * @return {Ember.Service} Firebase service
+ */
+export default function mockCloudFirestore(context, fixtureData) {
+  const mockFirebase = new MockFirebase();
+  const mockFirebasePojo = {
+    _data: fixtureData,
+    initializeApp: mockFirebase.initializeApp,
+    firestore: mockFirebase.firestore,
+  };
+  const firebaseService = Service.extend(mockFirebasePojo);
+
+  context.owner.register(`service:firebase`, firebaseService);
+
+  return context.owner.lookup('service:firebase', { as: 'firebase' });
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-cloud-firestore-adapter",
-  "version": "0.1.1",
+  "version": "0.1.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8727,6 +8727,11 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/mktemp/-/mktemp-0.4.0.tgz",
       "integrity": "sha1-bQUVYRyKjITkhKogABKbmOmB/ws="
+    },
+    "mock-cloud-firestore": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/mock-cloud-firestore/-/mock-cloud-firestore-0.0.3.tgz",
+      "integrity": "sha512-Yk/uj5UwVI8KcqZoYWRV6qHc27lDqdxfaIzzXRIZvosEkZHH+AXlLX4hCzJzfBk00gJI1eDyXVXKnrW2cQ3Gqg=="
     },
     "moo-server": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "broccoli-funnel": "^2.0.1",
-    "ember-cli-babel": "^6.6.0"
+    "ember-cli-babel": "^6.6.0",
+    "mock-cloud-firestore": "^0.0.3"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",


### PR DESCRIPTION
Exposes a [mock-cloud-firestore](https://github.com/rmmmp/mock-cloud-firestore) test helper.

Docs will come soon once I've plotted out a migration away from Mirage.