### PR TITLE
Fix relationship bug

### DIFF
--- a/addon/serializers/cloud-firestore.js
+++ b/addon/serializers/cloud-firestore.js
@@ -138,6 +138,21 @@ export default JSONSerializer.extend({
   },
 
   /**
+   * @override
+   */
+  serialize(snapshot, ...args) {
+    const json = this._super(snapshot, ...args);
+
+    snapshot.eachRelationship((name, relationship) => {
+      if (relationship.kind === 'hasMany') {
+        delete json[name];
+      }
+    });
+
+    return json;
+  },
+
+  /**
    * Returns an attribute from the snapshot adapter options if it exists
    *
    * @param {Object} snapshot


### PR DESCRIPTION
This fixes an issue where the `hasMany` relationship are being included in the payload when saving a record. `hasMany` relationships should be saved manually by [batching](https://github.com/rmmmp/ember-cloud-firestore-adapter/blob/master/guides/04-creating-updating-deleting-records.md#batched-writes) it.