### PR TITLE
Makes firestore a singleton and sets correct timestamp setting

### DIFF
--- a/addon/adapters/cloud-firestore.js
+++ b/addon/adapters/cloud-firestore.js
@@ -19,7 +19,7 @@ export default RESTAdapter.extend({
   /**
    * @type {Ember.Service}
    */
-  firebase: inject(),
+  firestore: inject(),
 
   /**
    * @type {string}
@@ -46,7 +46,7 @@ export default RESTAdapter.extend({
    * @override
    */
   generateIdForRecord(store, type) {
-    const db = this.get('firebase').firestore();
+    const db = this.get('firestore.instance');
     const collectionName = buildCollectionName(type);
 
     return db.collection(collectionName).doc().id;
@@ -139,7 +139,7 @@ export default RESTAdapter.extend({
       return this._super(store, type, snapshot);
     } else {
       return new Promise((resolve, reject) => {
-        const db = this.get('firebase').firestore();
+        const db = this.get('firestore.instance');
         const docRef = db
           .collection(buildCollectionName(type.modelName))
           .doc(snapshot.id);
@@ -159,7 +159,7 @@ export default RESTAdapter.extend({
    */
   findAll(store, type) {
     return new Promise((resolve, reject) => {
-      const db = this.get('firebase').firestore();
+      const db = this.get('firestore.instance');
       const collectionName = buildCollectionName(type.modelName);
       const collectionRef = db.collection(collectionName);
       const unsubscribe = collectionRef.onSnapshot((querySnapshot) => {
@@ -196,7 +196,7 @@ export default RESTAdapter.extend({
    */
   findRecord(store, type, id, snapshot = {}) {
     return new Promise((resolve, reject) => {
-      const db = this.get('firebase').firestore();
+      const db = this.get('firestore.instance');
       const collectionRef = this.buildCollectionRef(
         type.modelName,
         snapshot.adapterOptions,
@@ -295,7 +295,7 @@ export default RESTAdapter.extend({
    */
   query(store, type, query = {}) {
     return new Promise((resolve, reject) => {
-      const db = this.get('firebase').firestore();
+      const db = this.get('firestore.instance');
       let collectionRef = this.buildCollectionRef(type.modelName, query, db);
 
       collectionRef = this.buildQuery(collectionRef, query);
@@ -375,7 +375,7 @@ export default RESTAdapter.extend({
    * @return {firebase.firestore.CollectionReference|firebase.firestore.Query} Reference
    */
   buildHasManyCollectionRef(store, snapshot, url, relationship) {
-    const db = this.get('firebase').firestore();
+    const db = this.get('firestore.instance');
     const cardinality = snapshot.type.determineRelationshipType(
       relationship,
       store,
@@ -426,7 +426,7 @@ export default RESTAdapter.extend({
     return this.buildCollectionRef(
       type.modelName,
       snapshot.adapterOptions,
-      this.get('firebase').firestore(),
+      this.get('firestore.instance'),
     ).doc(snapshot.id);
   },
 
@@ -441,7 +441,7 @@ export default RESTAdapter.extend({
    * @private
    */
   buildWriteBatch(type, snapshot, docRef, isDeletingMainDoc) {
-    const db = this.get('firebase').firestore();
+    const db = this.get('firestore.instance');
     const payload = this.serialize(snapshot);
     const batch = db.batch();
 

--- a/addon/serializers/cloud-firestore.js
+++ b/addon/serializers/cloud-firestore.js
@@ -17,7 +17,7 @@ export default JSONSerializer.extend({
   /**
    * @type {Ember.Service}
    */
-  firebase: inject(),
+  firestore: inject(),
 
   /**
    * Overriden to properly get the data of a `Reference` type relationship
@@ -101,7 +101,7 @@ export default JSONSerializer.extend({
         json[relationship.key] = path;
       } else {
         json[relationship.key] = buildRefFromPath(
-          this.get('firebase').firestore(),
+          this.get('firestore.instance'),
           path,
         );
       }
@@ -125,7 +125,7 @@ export default JSONSerializer.extend({
           references.push(path);
         } else {
           references.push(buildRefFromPath(
-            this.get('firebase').firestore(),
+            this.get('firestore.instance'),
             path,
           ));
         }

--- a/addon/services/firestore.js
+++ b/addon/services/firestore.js
@@ -4,7 +4,7 @@ import { inject as service } from '@ember/service';
 export default Service.extend({
   firebase: service(),
   instance: null,
-  settings: { timestampInSnapshots: true },
+  settings: { timestampsInSnapshots: true },
 
   init(...args) {
     this._super(...args);

--- a/addon/services/firestore.js
+++ b/addon/services/firestore.js
@@ -1,0 +1,15 @@
+import Service from '@ember/service';
+import { inject as service } from '@ember/service';
+import { computed } from '@ember/object';
+
+export default Service.extend({
+  firebase: service(),
+  instance: computed('firebase', function() {
+    const firestore = this.get('firebase').firestore();
+    if (firestore.settings) {
+      const settings = { timestampsInSnapshots: true };
+      firestore.settings(settings);
+    }
+    return firestore;
+  }),
+});

--- a/addon/services/firestore.js
+++ b/addon/services/firestore.js
@@ -1,15 +1,20 @@
 import Service from '@ember/service';
 import { inject as service } from '@ember/service';
-import { computed } from '@ember/object';
 
 export default Service.extend({
   firebase: service(),
-  instance: computed('firebase', function() {
+  instance: null,
+  settings: { timestampInSnapshots: true },
+
+  init(...args) {
+    this._super(...args);
+
     const firestore = this.get('firebase').firestore();
+
     if (firestore.settings) {
-      const settings = { timestampsInSnapshots: true };
-      firestore.settings(settings);
+      firestore.settings(this.settings);
     }
-    return firestore;
-  }),
+
+    this.set('instance', firestore);
+  },
 });

--- a/app/services/firestore.js
+++ b/app/services/firestore.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-cloud-firestore-adapter/services/firestore';

--- a/tests/unit/adapters/cloud-firestore-test.js
+++ b/tests/unit/adapters/cloud-firestore-test.js
@@ -265,27 +265,25 @@ module('Unit | Adapter | cloud firestore', function(hooks) {
       const snapshot = { id: 'user_a' };
       const adapter = this.owner.lookup('adapter:cloud-firestore');
 
-      adapter.set('firebase', {
-        firestore() {
-          return {
-            batch() {
-              return {
-                set() {},
+      adapter.set('firestore', {
+        instance: {
+          batch() {
+            return {
+              set() {},
 
-                commit() {
-                  return Promise.reject('error');
-                },
-              };
-            },
+              commit() {
+                return Promise.reject('error');
+              },
+            };
+          },
 
-            collection() {
-              return {
-                doc() {
-                  return {};
-                },
-              };
-            },
-          };
+          collection() {
+            return {
+              doc() {
+                return {};
+              },
+            };
+          },
         },
       });
       adapter.set('serialize', () => {
@@ -369,25 +367,23 @@ module('Unit | Adapter | cloud firestore', function(hooks) {
       const snapshot = { id: 'user_a' };
       const adapter = this.owner.lookup('adapter:cloud-firestore');
 
-      adapter.set('firebase', {
-        firestore() {
-          return {
-            batch() {
-              return {
-                commit() {
-                  return Promise.reject('error');
-                },
+      adapter.set('firestore', {
+        instance: {
+          batch() {
+            return {
+              commit() {
+                return Promise.reject('error');
+              },
 
-                delete() {},
-              };
-            },
+              delete() {},
+            };
+          },
 
-            collection() {
-              return {
-                doc() {},
-              };
-            },
-          };
+          collection() {
+            return {
+              doc() {},
+            };
+          },
         },
       });
       adapter.set('serialize', () => {
@@ -450,17 +446,15 @@ module('Unit | Adapter | cloud firestore', function(hooks) {
       // Arrange
       const adapter = this.owner.lookup('adapter:cloud-firestore');
 
-      adapter.set('firebase', {
-        firestore() {
-          return {
-            collection() {
-              return {
-                onSnapshot(onSuccess, onError) {
-                  onError();
-                },
-              };
-            },
-          };
+      adapter.set('firestore', {
+        instance: {
+          collection() {
+            return {
+              onSnapshot(onSuccess, onError) {
+                onError();
+              },
+            };
+          },
         },
       });
 
@@ -544,21 +538,19 @@ module('Unit | Adapter | cloud firestore', function(hooks) {
       const modelId = 'user_a';
       const adapter = this.owner.lookup('adapter:cloud-firestore');
 
-      adapter.set('firebase', {
-        firestore() {
-          return {
-            collection() {
-              return {
-                doc() {
-                  return {
-                    onSnapshot(onSuccess, onError) {
-                      onError();
-                    },
-                  };
-                },
-              };
-            },
-          };
+      adapter.set('firestore', {
+        instance: {
+          collection() {
+            return {
+              doc() {
+                return {
+                  onSnapshot(onSuccess, onError) {
+                    onError();
+                  },
+                };
+              },
+            };
+          },
         },
       });
 
@@ -916,21 +908,19 @@ module('Unit | Adapter | cloud firestore', function(hooks) {
       };
       const adapter = this.owner.lookup('adapter:cloud-firestore');
 
-      adapter.set('firebase', {
-        firestore() {
-          return {
-            collection() {
-              return {
-                where() {
-                  return {
-                    onSnapshot(onSuccess, onError) {
-                      onError();
-                    },
-                  };
-                },
-              };
-            },
-          };
+      adapter.set('firestore', {
+        instance: {
+          collection() {
+            return {
+              where() {
+                return {
+                  onSnapshot(onSuccess, onError) {
+                    onError();
+                  },
+                };
+              },
+            };
+          },
         },
       });
 

--- a/tests/unit/services/firestore-test.js
+++ b/tests/unit/services/firestore-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
+
+module('Unit | Service | firestore', function(hooks) {
+  setupTest(hooks);
+
+  // Replace this with your real tests.
+  test('it exists', function(assert) {
+    const service = this.owner.lookup('service:firestore');
+    assert.ok(service);
+  });
+});
+


### PR DESCRIPTION
I made the `firestore` instance a singleton on a newly created `firestore` service.
When asked for the instance I will also set the right settings getting rid of the deprecation warning in #43 